### PR TITLE
AD-627 - Error handling and auto recovery of connection failures on producer side 

### DIFF
--- a/lib/message_queue.rb
+++ b/lib/message_queue.rb
@@ -134,16 +134,18 @@ module MessageQueue
   # Internal: Register a error handler.
   #
   # Returns the registered error handlers.
+  #
+  # message_queue uses the following error handler types:
+  #  - :message for consumer errors during handling message
   def register_error_handler(type, error_handler)
-    error_handlers[type] ||= []
-    error_handlers[type] << error_handler
+    @error_handlers ||= {}
+    @error_handlers[type] ||= []
+    @error_handlers[type] << error_handler
   end
 
-  # Internal: Get the list of error handlers.
-  #
-  # Returns the list of error handlers.
-  def error_handlers
-    @error_handlers ||= {}
+  # Internal: Returns an error handler for given type.
+  def error_handlers_for(type)
+    @error_handlers[type] || []
   end
 
   # Internal: Get the list of consumables.

--- a/lib/message_queue.rb
+++ b/lib/message_queue.rb
@@ -136,6 +136,7 @@ module MessageQueue
   # Returns the registered error handlers.
   #
   # message_queue uses the following error handler types:
+  #  - :connection for producer error trying to connect to rabbitmq server.
   #  - :message for consumer errors during handling message
   def register_error_handler(type, error_handler)
     @error_handlers ||= {}

--- a/lib/message_queue.rb
+++ b/lib/message_queue.rb
@@ -134,15 +134,16 @@ module MessageQueue
   # Internal: Register a error handler.
   #
   # Returns the registered error handlers.
-  def register_error_handler(error_handler)
-    error_handlers << error_handler
+  def register_error_handler(type, error_handler)
+    error_handlers[type] ||= []
+    error_handlers[type] << error_handler
   end
 
   # Internal: Get the list of error handlers.
   #
   # Returns the list of error handlers.
   def error_handlers
-    @error_handlers ||= []
+    @error_handlers ||= {}
   end
 
   # Internal: Get the list of consumables.

--- a/lib/message_queue.rb
+++ b/lib/message_queue.rb
@@ -29,7 +29,7 @@ module MessageQueue
       file_or_options = YAML.load_file(file_or_options).inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo}
     end
 
-    @settings = file_or_options.to_hash
+    @settings = file_or_options
     @connection = new_connection(@settings)
     @connection.connect
   end
@@ -74,7 +74,6 @@ module MessageQueue
   # Returns the connection for the specified message queue.
   # Raises a RuntimeError if an adapter can't be found.
   def new_connection(options = {})
-    options = options.to_hash
     adapter = load_adapter(options[:adapter])
     raise "Missing adapter #{options[:adapter]}" unless adapter
 
@@ -95,7 +94,6 @@ module MessageQueue
   # Returns nothing
   # Raises a RuntimeError if an adapter can't be found.
   def with_connection(options = {}, &block)
-    options = options.to_hash
     connection = new_connection(options)
     connection.with_connection(&block)
   end
@@ -106,7 +104,6 @@ module MessageQueue
   #
   # Returns a new producer
   def new_producer(options = {})
-    options = options.to_hash
     connection.new_producer(options)
   end
 
@@ -116,7 +113,6 @@ module MessageQueue
   #
   # Returns a new consumer
   def new_consumer(options = {})
-    options = options.to_hash
     connection.new_consumer(options)
   end
 

--- a/lib/message_queue/adapters/bunny/producer.rb
+++ b/lib/message_queue/adapters/bunny/producer.rb
@@ -23,18 +23,23 @@ class MessageQueue::Adapters::Bunny::Connection::Producer < MessageQueue::Produc
   def initialize(connection, options = {})
     super
 
+    @connection = connection
     @exchange_options = self.options.fetch(:exchange)
     @exchange_name = exchange_options.delete(:name) || (raise "Missing exchange name")
     @exchange_type = exchange_options.delete(:type) || (raise "Missing exchange type")
-
     @message_options = self.options.fetch(:message)
+
+    return unless connection.verify_connection
 
     @exchange = connection.connection.default_channel.send(exchange_type, exchange_name, exchange_options)
   end
 
   def publish(object, options = {})
+    return false unless exchange
+
     options = message_options.merge(default_options).merge(options)
     object = dump_object(object)
+
     exchange.publish(object, options)
   end
 end

--- a/lib/message_queue/connection.rb
+++ b/lib/message_queue/connection.rb
@@ -32,6 +32,15 @@ class MessageQueue::Connection
     logger.info("Disconnecting from message queue")
   end
 
+  # Public: Disconnect and re-connect to the message queue
+  #
+  # Returns nothing
+  def reconnect
+
+    disconnect
+    connect
+  end
+
   # Public: Check if it's connected to the message queue
   #
   # Returns true if it's connected

--- a/lib/message_queue/consumable.rb
+++ b/lib/message_queue/consumable.rb
@@ -59,6 +59,8 @@ module MessageQueue
     def subscribe(options = {})
       @consumer.subscribe(options) do |message|
         begin
+          # message.routing_key randomly becomes encoded in ASCII-8BIT which causes the following:
+          # Encoding::CompatibilityError - incompatible character encodings: ASCII-8BIT and UTF-8
           message.routing_key.force_encoding("UTF-8")
           logger.info("Message(#{message.message_id || '-'}): " +
                       "routing key: #{message.routing_key}, " +

--- a/lib/message_queue/consumable.rb
+++ b/lib/message_queue/consumable.rb
@@ -59,6 +59,7 @@ module MessageQueue
     def subscribe(options = {})
       @consumer.subscribe(options) do |message|
         begin
+          message.routing_key.force_encoding("UTF-8")
           logger.info("Message(#{message.message_id || '-'}): " +
                       "routing key: #{message.routing_key}, " +
                       "type: #{message.type}, " +

--- a/lib/message_queue/consumable.rb
+++ b/lib/message_queue/consumable.rb
@@ -62,12 +62,12 @@ module MessageQueue
           # message.routing_key randomly becomes encoded in ASCII-8BIT which causes the following:
           # Encoding::CompatibilityError - incompatible character encodings: ASCII-8BIT and UTF-8
           message.routing_key.force_encoding("UTF-8")
-          logger.info("Message(#{message.message_id || '-'}): " +
-                      "routing key: #{message.routing_key}, " +
-                      "type: #{message.type}, " +
-                      "timestamp: #{message.timestamp}, " +
-                      "consumer: #{@consumer.class}, " +
-                      "payload: #{message.payload}")
+          logger.info("Message(#{(message.message_id || '-').force_encoding("UTF-8")}): " +
+                      "routing key: #{message.routing_key.force_encoding("UTF-8")}, " +
+                      "type: #{message.type.force_encoding("UTF-8")}, " +
+                      "timestamp: #{message.timestamp.to_s.force_encoding("UTF-8")}, " +
+                      "consumer: #{@consumer.class.to_s.force_encoding("UTF-8")}, " +
+                      "payload: #{message.payload.to_s.force_encoding("UTF-8")}")
           process(message)
         rescue StandardError => ex
           handle_error(message, @consumer, ex)

--- a/lib/message_queue/consumable.rb
+++ b/lib/message_queue/consumable.rb
@@ -78,7 +78,9 @@ module MessageQueue
     private
 
     def handle_error(message, consumer, ex)
-      MessageQueue.error_handlers.each do |handler|
+      return unless handlers = MessageQueue.error_handlers[:message]
+
+      handlers.each do |handler|
         handler.handle(message, consumer, ex)
       end
     end

--- a/lib/message_queue/consumable.rb
+++ b/lib/message_queue/consumable.rb
@@ -64,7 +64,7 @@ module MessageQueue
           message.routing_key.force_encoding("UTF-8")
           logger.info("Message(#{(message.message_id || '-').force_encoding("UTF-8")}): " +
                       "routing key: #{message.routing_key.force_encoding("UTF-8")}, " +
-                      "type: #{message.type.force_encoding("UTF-8")}, " +
+                      "type: #{message.type.to_s.force_encoding("UTF-8")}, " +
                       "timestamp: #{message.timestamp.to_s.force_encoding("UTF-8")}, " +
                       "consumer: #{@consumer.class.to_s.force_encoding("UTF-8")}, " +
                       "payload: #{message.payload.to_s.force_encoding("UTF-8")}")

--- a/lib/message_queue/consumable.rb
+++ b/lib/message_queue/consumable.rb
@@ -78,9 +78,7 @@ module MessageQueue
     private
 
     def handle_error(message, consumer, ex)
-      return unless handlers = MessageQueue.error_handlers[:message]
-
-      handlers.each do |handler|
+      MessageQueue.error_handlers_for(:message).each do |handler|
         handler.handle(message, consumer, ex)
       end
     end

--- a/lib/message_queue/error_handlers/airbrake.rb
+++ b/lib/message_queue/error_handlers/airbrake.rb
@@ -15,5 +15,5 @@ if defined?(Airbrake)
     end
   end
 
-  MessageQueue.register_error_handler MessageQueue::ErrorHandlers::Airbrake.new
+  MessageQueue.register_error_handler :message, MessageQueue::ErrorHandlers::Airbrake.new
 end

--- a/lib/message_queue/error_handlers/logger.rb
+++ b/lib/message_queue/error_handlers/logger.rb
@@ -13,4 +13,4 @@ module MessageQueue
   end
 end
 
-MessageQueue.register_error_handler MessageQueue::ErrorHandlers::Logger.new
+MessageQueue.register_error_handler :message, MessageQueue::ErrorHandlers::Logger.new

--- a/lib/message_queue/error_handlers/logger.rb
+++ b/lib/message_queue/error_handlers/logger.rb
@@ -1,16 +1,25 @@
 module MessageQueue
   module ErrorHandlers
-    class Logger
+    class ConnectionLogger
+      include Logging
+
+      def handle(ex)
+        log_exception(ex)
+      end
+    end
+
+    class MessageLogger
       include Logging
 
       def handle(message, consumer, ex)
         prefix = "Message(#{message.message_id || '-'}): "
         logger.error prefix + "error in consumer '#{consumer}'"
-        logger.error prefix + "#{ex.class} - #{ex.message}"
-        logger.error (['backtrace:'] + ex.backtrace).join("\n")
+
+        log_exception(ex)
       end
     end
   end
 end
 
-MessageQueue.register_error_handler :message, MessageQueue::ErrorHandlers::Logger.new
+MessageQueue.register_error_handler :connection, MessageQueue::ErrorHandlers::ConnectionLogger.new
+MessageQueue.register_error_handler :message, MessageQueue::ErrorHandlers::MessageLogger.new

--- a/lib/message_queue/logging.rb
+++ b/lib/message_queue/logging.rb
@@ -26,5 +26,10 @@ module MessageQueue
     def logger
       Logging.logger
     end
+
+    def log_exception(ex)
+      logger.error "#{self.class.name} Error: #{ex.class} - #{ex.message}"
+      logger.error (['backtrace:'] + ex.backtrace).join("\n")
+    end
   end
 end

--- a/message_queue.gemspec
+++ b/message_queue.gemspec
@@ -19,7 +19,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "bunny"
+  spec.add_development_dependency "bunny", "~> 1.2.0"
   spec.add_development_dependency "msgpack"
   spec.add_development_dependency "multi_json"
+  spec.add_development_dependency "pry"
 end

--- a/test/consumable_test.rb
+++ b/test/consumable_test.rb
@@ -7,27 +7,6 @@ class ConsumableTest < Test::Unit::TestCase
     include MessageQueue::Consumable
   end
 
-  class TestLogger
-    attr_reader :buffer
-
-    def initialize(*)
-      @buffer = ''
-    end
-
-    def log(string)
-      @buffer << string
-    end
-
-    alias :info :log
-    alias :error :log
-  end
-
-  class TestHandler < TestLogger
-    def handle(message, consumer, ex)
-      log(ex.message)
-    end
-  end
-
   def setup
     @original_logger = MessageQueue::Logging.logger
     @test_logger = TestLogger.new

--- a/test/consumable_test.rb
+++ b/test/consumable_test.rb
@@ -8,16 +8,15 @@ class ConsumableTest < Test::Unit::TestCase
   end
 
   def setup
-    @original_logger = MessageQueue::Logging.logger
-    @test_logger = TestLogger.new
-    MessageQueue::Logging.logger = @test_logger
+    start_test_logger
 
     MessageQueue.connect(:adapter => :bunny, :serializer => :plain)
   end
 
   def teardown
     MessageQueue.disconnect
-    MessageQueue::Logging.logger = @original_logger
+
+    stop_test_logger
   end
 
   def build_producer
@@ -87,7 +86,7 @@ class ConsumableTest < Test::Unit::TestCase
   end
 
   def test_consumable_custom_error_handler
-    test_handler = TestHandler.new
+    test_handler = TestMessageHandler.new
     MessageQueue.register_error_handler :message, test_handler
 
     configure_invalid_consumer
@@ -104,7 +103,7 @@ class ConsumableTest < Test::Unit::TestCase
   end
 
   def test_consumable_does_not_use_unrelated_handler_types
-    test_handler = TestHandler.new
+    test_handler = TestMessageHandler.new
     MessageQueue.register_error_handler :connection, test_handler
 
     configure_invalid_consumer

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,8 +16,26 @@ class TestLogger
   alias :error :log
 end
 
-class TestHandler < TestLogger
+class TestConnectionHandler < TestLogger
+  def handle(ex)
+    log(ex.message)
+  end
+end
+
+class TestMessageHandler < TestLogger
   def handle(message, consumer, ex)
     log(ex.message)
   end
+end
+
+def start_test_logger
+  @original_logger = MessageQueue::Logging.logger
+  @test_logger = TestLogger.new
+  MessageQueue::Logging.logger = @test_logger
+
+  ErrorBunny::ErrorBunnyConnection.bunny_adapter_class = ErrorBunny::ErrorBunnyAdapter
+end
+
+def stop_test_logger
+  MessageQueue::Logging.logger = @original_logger
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,2 +1,23 @@
 require "test/unit"
 require_relative "../lib/message_queue"
+
+class TestLogger
+  attr_reader :buffer
+
+  def initialize(*)
+    @buffer = ''
+  end
+
+  def log(string)
+    @buffer << string
+  end
+
+  alias :info :log
+  alias :error :log
+end
+
+class TestHandler < TestLogger
+  def handle(message, consumer, ex)
+    log(ex.message)
+  end
+end


### PR DESCRIPTION
Fixes first phase of https://aclgrc.atlassian.net/browse/AD-627 - log and recover from message queue server downtime on producer side.

Didn't make change for consumers yet as there is less urgent need and we should test one thing at a time.
